### PR TITLE
live uninstall luet nolock

### DIFF
--- a/packages/mocaccino/mocaccino-calamares/mocaccino/main.py
+++ b/packages/mocaccino/mocaccino-calamares/mocaccino/main.py
@@ -127,7 +127,7 @@ def run():
     configure_services(install_path)
 
     if len(luet_packages2remove) > 0:
-        args = ["luet", "uninstall", "-y"]
+        args = ["env", "-i", "LUET_NOLOCK=true", "luet", "uninstall", "-y"]
         # args = args + luet_packages2remove
         # libcalamares.utils.target_env_call(args)
         # Temporary trying to remove every package singolary


### PR DESCRIPTION
Luet can't unistall live packages at the end of the OS installation due to reported access problems, so LUET_NOLOCK=true is set in order to succeed.