### PR TITLE
Add /run/lock to the installed rootfs

### DIFF
--- a/packages/mocaccino/mocaccino-calamares/modules-conf/modules/mount.conf
+++ b/packages/mocaccino/mocaccino-calamares/modules-conf/modules/mount.conf
@@ -29,7 +29,10 @@ extraMounts:
     - device: /run/udev
       mountPoint: /run/udev
       options: bind
-
+    - device: /run/lock
+      mountPoint: /run/lock
+      options: bind
+      
 extraMountsEfi:
     - device: efivarfs
       fs: efivarfs


### PR DESCRIPTION
Add /run/lock to the target rootfs in order to fix the link of /var/lock to it and be able to use luet uninstall for removing the live packages.